### PR TITLE
Add support for async handlers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,12 @@
             :url "http://opensource.org/licenses/MIT"}
   ;; :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8" "test"]}
   :profiles
-  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}
+  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
+                        [javax.servlet/javax.servlet-api "4.0.1" :scope "provided"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}})
+   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+   :test {:dependencies [[ring/ring-jetty-adapter "1.6.3"]
+                         [org.eclipse.jetty/jetty-servlet "9.2.24.v20180105"]
+                         [ring/ring-servlet "1.6.3"]
+                         [clj-http "3.9.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://opensource.org/licenses/MIT"}
   ;; :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8" "test"]}
   :profiles
-  {:dev {:dependencies [[org.clojure/clojure "1.5.1"]]}
+  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/src/ring/middleware/servlet_context.clj
+++ b/src/ring/middleware/servlet_context.clj
@@ -1,15 +1,19 @@
-(ns ring.middleware.servlet-context)
+(ns ring.middleware.servlet-context
+  (:import javax.servlet.http.HttpServletRequest))
+
+(defn- update-uri [{:keys [servlet-request ^String uri] :as request}]
+  (if servlet-request
+    (let [context (.getContextPath ^HttpServletRequest servlet-request)]
+      (if (.startsWith uri context)
+        (assoc request :uri (.substring uri (.length context)))
+        request))
+    request))
 
 (defn wrap-servlet-context
   "Removes the servlet context path from requested URI"
   [handler]
-  (fn [request]
-    (handler
-     (if-let [servlet-req (:servlet-request request)]
-       (let [context (.getContextPath ^javax.servlet.http.HttpServletRequest servlet-req)
-             uri ^String (:uri request)]
-         (if (.startsWith uri context)
-           (assoc request :uri
-                  (.substring uri (.length context)))
-           request))
-       request))))
+  (fn servlet-context-wrapped-handler
+    ([request]
+     (handler (update-uri request)))
+    ([request respond raise]
+     (handler (update-uri request) respond raise))))

--- a/test/ring/middleware/servlet_context_test.clj
+++ b/test/ring/middleware/servlet_context_test.clj
@@ -1,0 +1,52 @@
+(ns ring.middleware.servlet-context-test
+  (:require [clojure.test :refer :all]
+            [ring.util.response :as response]
+            [ring.util.servlet :as servlet]
+            [ring.adapter.jetty :as jetty]
+            [clj-http.client :as http]
+            [ring.middleware.servlet-context :as sc])
+  (:import org.eclipse.jetty.server.Server
+           [org.eclipse.jetty.servlet ServletContextHandler ServletHolder]))
+
+(defn- wrap-servlet-handler [handler opts]
+  (fn [^Server server]
+    (->> "/*"
+         (.addServlet (ServletHolder. (servlet/servlet handler opts)))
+         (doto (ServletContextHandler.)
+           (.setContextPath (:servlet-context-path opts)))
+         (.setHandler server))))
+
+(defn- get-resolved-uri [{:keys [async? port servlet-context-path] :as opts}]
+  (let [handler (sc/wrap-servlet-context
+                    (if async?
+                      (fn [request respond raise]
+                        (respond (response/response (:uri request))))
+                      (fn [request]
+                        (response/response (:uri request)))))
+        server (jetty/run-jetty
+                (when-not servlet-context-path handler)
+                (assoc opts :configurator
+                       (when servlet-context-path
+                         (wrap-servlet-handler handler opts))))]
+    (try
+      (:body (http/get (str "http://localhost:" port "/foo/bar/baz")))
+      (finally
+        (.stop server)))))
+
+(deftest root-sync-handler
+  (is (get-resolved-uri {:async? false, :join? false, :port 54321})
+      "/foo/bar/baz"))
+
+(deftest root-async-handler
+  (is (get-resolved-uri {:async? true, :join? false, :port 54322})
+      "/foo/bar/baz"))
+
+(deftest servlet-sync-handler
+  (is (get-resolved-uri {:async? false, :join? false, :port 54323,
+                         :servlet-context-path "/foo"})
+      "/bar/baz"))
+
+(deftest servlet-async-handler
+  (is (get-resolved-uri {:async? true, :join? false, :port 54324,
+                         :servlet-context-path "/foo"})
+      "/bar/baz"))


### PR DESCRIPTION
This PR extends the `wrap-servlet-context` middleware so that it can be used with [3-arity asynchronous handlers](https://github.com/ring-clojure/ring/wiki/Concepts#handlers).